### PR TITLE
Added schedule, record and game logs functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # VS Code Settings
 .vscode/
+
+# Ignore manifest file changes to avoid plugin from being removed
+.well-known/

--- a/main.py
+++ b/main.py
@@ -14,15 +14,15 @@ from pybaseball import \
 standings, batting_stats_bref, pitching_stats_bref, team_batting_bref, team_fielding_bref, \
 team_pitching_bref, playerid_lookup, statcast_batter, statcast_outs_above_average, \
 statcast_pitcher, top_prospects, batting_stats, team_batting, starting_pitching_stats, \
-relief_pitching_stats, cache, team_pitching
+relief_pitching_stats, cache, team_pitching, schedule_and_record, team_game_logs
 
 import pandas as pd
 
 
 # Note: Setting CORS to allow chat.openapi.com is only required when running a localhost plugin
-# app = quart_cors.cors(quart.Quart(__name__), allow_origin="https://chat.openai.com")
+app = quart_cors.cors(quart.Quart(__name__), allow_origin="https://chat.openai.com")
 
-app = quart.Quart(__name__)
+# app = quart.Quart(__name__)
 
 cache.enable()
 
@@ -165,8 +165,12 @@ async def get_team_batting_combined():
     # Returns the combined batting statistics for each team across the MLB for the season being specified
     year = int(request.args.get("year"))
     team_abr = request.args.get('team_abbreviation')
+    batting_stat = request.args.get('batting_stat')
+
     team_batting_stats = team_batting(year)
-    if team_abr != None:
+
+
+    if team_abr != None: # Get's a bunch of combined batting stats for one specific team
         team_batting_stats = team_batting_stats[team_batting_stats['Team'] == team_abr]
     
     else:
@@ -175,6 +179,10 @@ async def get_team_batting_combined():
         cols = [cols[2]] + cols[:2] + cols[3:]
         team_batting_stats = team_batting_stats[cols]
         team_batting_stats = team_batting_stats.iloc[:, :40] # consider adding more columns
+
+    if batting_stat != None: # Filter a single stat 
+        team_batting_stats = team_batting_stats[['Team',batting_stat]]
+        team_batting_stats = team_batting_stats.sort_values(by=batting_stat, ascending=False)
         
     team_batting_stats = json.loads(team_batting_stats.to_json(orient='records'))
     
@@ -298,7 +306,7 @@ async def get_statcast_pitcher():
         pass
     else:
         date_format = "%Y-%m-%d"
-        date = datetime.strptime(starting_date, date_format)
+        date = datetime.strptime('', date_format)
         if date.year < 2008:
             return quart.Response("The starting date is before statcast data started being collected in 2008.", status=500)
 
@@ -318,13 +326,47 @@ async def get_top_prospects():
     team_name = request.args.get('team_name')
     player_type = request.args.get('player_type')
     prospects = top_prospects(teamName=team_name,playerType=player_type)
-    # We must cut down to top 50 prospects due to rate limiting from OpenAI
+    # We must cut down to top 50 prospects due to token limit from OpenAI
     prospects = prospects.head(50)
 
     prospects = json.loads(prospects.to_json(orient='records'))
     
 
     return quart.Response(json.dumps(prospects), content_type='application/json')
+
+@app.get("/schedule_and_record")
+async def get_schedule_and_record():
+    # Retrieves the schedule and record of game-level results for a given month of a season
+    year = int(request.args.get('year'))
+    month = request.args.get('month')
+    team_abr = request.args.get('team_abbreviation')
+
+    team_record = schedule_and_record(year, team_abr)
+    team_record = team_record.iloc[:, :-1]
+    # Must filter the data based on the month due to token limits
+    team_record = team_record[team_record['Date'].str.contains(month)]
+    team_record = json.loads(team_record.to_json(orient='records'))
+
+
+    return quart.Response(json.dumps(team_record), content_type='application/json')
+
+@app.get("/team_game_logs")
+async def get_team_game_logs():
+    # Retrieves detailed batting or pitching statistics for a team over a month time period
+    year = int(request.args.get('year'))
+    month = request.args.get('month')
+    team_abr = request.args.get('team_abbreviation')
+    stat = request.args.get('stat')
+
+    game_logs = team_game_logs(year,team_abr,stat)
+    # Must filter the data based on the month due to token limits
+    game_logs = game_logs[game_logs['Date'].str.contains(month)]
+    
+    game_logs = json.loads(game_logs.to_json(orient='records'))
+
+
+    return quart.Response(json.dumps(game_logs), content_type='application/json')
+
 
 
 @app.get("/logo.png")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
     description: Get current and historical statistics for MLB players, teams, games, and seasons.
     version: "v1"
 servers:
-    - url: http://localhost:8000/
+    - url: https://baseball-stats.azurewebsites.net/
 paths:
     /standings:
         get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
     description: Get current and historical statistics for MLB players, teams, games, and seasons.
     version: "v1"
 servers:
-    - url: https://baseball-stats.azurewebsites.net/
+    - url: http://localhost:8000/
 paths:
     /standings:
         get:
@@ -251,6 +251,16 @@ paths:
                   The 3 letter abbreviated name of the baseball team. This parameter should be passed 
                   to get the combined statistics for a specific team. 
                 example: NYY
+              - in: query 
+                name: batting_stat
+                required: false
+                schema: 
+                  type: string
+                  enum: ['H', '2B', '3B', 'HR', 'RBI', 'BB', 'IBB', 'SO', 'HBP', 'SH', 'SF', 'GDP', 'SB', 'CS', 'AVG', 
+                      'OBP', 'SLG', 'OPS']
+                description: >
+                  Can be used to filter based on a certain batting statistic. 
+                  Calling the function without this parameter can be used to get an overall view of stats returned from the function. 
             responses:
               "200":
                 description: OK
@@ -438,8 +448,8 @@ paths:
           summary: Retrieves pitch-level statistics from Statcast for a pitcher for a specified date.
           parameters:
               - in: query
-                name: start_date
-                required: false
+                name: date
+                required: true
                 description: The date from which data will be retrieved. 
                 schema:
                   type: string
@@ -495,6 +505,86 @@ paths:
                 application/json:
                   schema: 
                     type: array
+
+    /schedule_and_record:
+        get:
+          operationId: getScheduleandRecord
+          description: >
+            Gets a month of game stats for a team, including win/loss, runs scored per game.
+            Can also be used to get the upcoming schedule.  
+            For detailed batting/pitching info, use 'getTeamGameLogs' operation.
+          parameters:
+            - in: query
+              name: year
+              required: true
+              schema:
+                type: integer
+              description: Used to select which season the statistics will be retrieved from
+            - in: query
+              name: month
+              required: true
+              schema:
+                type: string
+                enum: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+              description: Used to select which month the statistics will be retrieved from.
+            - in: query
+              name: team_abbreviation
+              required: true
+              schema: 
+                type: string
+              description: The 3 letter abbreviated name of the baseball team.
+          responses:
+            "200":
+              description: An array of high level game statistics
+              content:
+                application/json:
+                  schema: 
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/getScheduleandRecordResponse'
+
+
+    /team_game_logs:
+        get:
+          operationId: getTeamGameLogs
+          summary: Gets a month of detailed batting or pitching game stats for a team. 
+          parameters:
+            - in: query
+              name: year
+              required: true
+              schema: 
+                type: integer
+              description: Used to select what season the results will be retrieved from.
+            - in: query
+              name: month
+              required: true
+              schema: 
+                type: string
+              description: Used to select which month the game logs will be retrieved from
+            - in: query
+              name: team_abbreviation
+              required: true
+              schema: 
+                type: string
+              description: The 3 letter abbreviated name of the baseball team
+            - in: query
+              name: stat
+              required: true
+              schema: 
+                type: string
+                enum: ['batting', 'pitching']
+              description: Used to select which set of statistics to retrieve. This will influence what kind of response is generated as well. 
+          responses:
+            "200":
+              description: An array of either batting or pitching statistics for games
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '#/components/schemas/getTeamGameLogsBattingResponse'
+                        - $ref: '#/components/schemas/getTeamGamesLogsPitchingResponse'
 
                 
 components:
@@ -716,6 +806,21 @@ components:
         BB:
           type: integer
           description: The combined number of base on balls - also known as walks - for the team
+        IBB:
+          type: integer
+          description: The combined number of intentional walks for the team
+        SO:
+          type: integer
+          description: The combined number of strikeouts for the team
+        HBP:
+          type: integer
+          description: The combined number of times players have been hit by a pitch
+        SLG:
+          type: number
+          description: The team's slugging percentage
+        OPS:
+          type: number
+          description: The team's On-base plus slugging percentage
         AVG:
           type: number
           description: The team's combined batting average
@@ -728,4 +833,211 @@ components:
         LD: 
           type: number
           description: The combined total number of line drives
+    
+    getScheduleandRecordResponse:
+      type: object
+      properties:
+        Date:
+          type: string
+          description: The date the game was played on 
+        Tm:
+          type: string
+          description: The team being queried
+        Home_Away:
+          type: string
+          description: >
+            Whether the team was playing at their home stadium or away. 
+            If the output is 'Home' the team was playing at home. 
+            If the output is '@' the team was playing away
+        Opp:
+          type: string
+          description: The opponent team
+        W/L:
+          type: string
+          description: Whether the team won or lost the game
+        R:
+          type: number
+          format: float
+          description: The number of runs the team scored 
+        RA:
+          type: number
+          format: float
+          description: The number of runs that were scored by the opposing team
+        Inn:
+          type: number
+          format: float
+        W-L:
+          type: string
+        Rank:
+          type: number
+          format: float
+        GB:
+          type: string
+          description: How many games behind the team is after the result of the game
+        Win:
+          type: string
+          description: The pitcher who is attributed with the win for the game
+        Loss:
+          type: string
+          description: The pitcher who is attributed with the loss for the game
+        Save:
+          type: string
+          description: The pitcher who is attributed with the save for the game
+        Time:
+          type: string
+        D/N:
+          type: string
+          description: Whether the game was a day or night game
+        Attendance:
+          type: number
+          format: float
+          nullable: true
+        cLI:
+          type: string
+        Streak:
+          type: number
+          format: float
         
+    getTeamGameLogsBattingResponse:
+      type: object
+      properties: 
+        Game:
+          type: integer
+        Date:
+          type: string
+        Home:
+          type: boolean
+        Opp:
+          type: string
+        PA:
+          type: integer
+        AB:
+          type: integer
+        R:
+          type: integer
+        H:
+          type: integer
+        "2B":
+          type: integer
+        "3B":
+          type: integer
+        HR:
+          type: integer
+        RBI:
+          type: integer
+        BB:
+          type: integer
+        IBB:
+          type: integer
+        SO:
+          type: integer
+        HBP:
+          type: integer
+        SH:
+          type: integer
+        SF:
+          type: integer
+        ROE:
+          type: integer
+        GDP:
+          type: integer
+        SB:
+          type: integer
+        CS:
+          type: integer
+        BA:
+          type: number
+          format: float
+        OBP:
+          type: number
+          format: float
+        SLG:
+          type: number
+          format: float
+        OPS:
+          type: number
+          format: float
+        LOB:
+          type: integer
+        NumPlayers:
+          type: integer
+        Thr:
+          type: string
+        OppStart:
+          type: string
+        W/L:
+          type: string
+        Score:
+          type: string
+
+    getTeamGamesLogsPitchingResponse:
+      type: object
+      properties:
+        Game:
+          type: integer
+        Date:
+          type: string
+        Home:
+          type: boolean
+        Opp:
+          type: string
+        IP:
+          type: number
+        H:
+          type: integer
+        R:
+          type: integer
+        ER:
+          type: integer
+        UER:
+          type: integer
+        BB:
+          type: integer
+        SO:
+          type: integer
+        HR:
+          type: integer
+        HBP:
+          type: integer
+        ERA:
+          type: number
+        BF:
+          type: integer
+        Pit:
+          type: integer
+        Str:
+          type: integer
+        IR:
+          type: integer
+        IS:
+          type: integer
+        SB:
+          type: integer
+        CS:
+          type: integer
+        AB:
+          type: integer
+        2B:
+          type: integer
+        3B:
+          type: integer
+        IBB:
+          type: integer
+        SH:
+          type: integer
+        SF:
+          type: integer
+        ROE:
+          type: integer
+        GDP:
+          type: integer
+        NumPlayers:
+          type: integer
+        Umpire:
+          type: string
+        PitchersUsed:
+          type: string
+        W/L:
+          type: string
+        Score:
+          type: string


### PR DESCRIPTION
Two new paths have been added : `team_game_logs` and `schedule_and_record`.

schedule_and_record -> retrieves high-level game record stats

team_game_logs -> retrieves more detailed batting OR pitching stats for games